### PR TITLE
Fix: docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     ports:
     - 8081:8081
     environment:
+    - TZ=Asia/Singapore
     - MONGODB_CONNECTION =$MONGODB_CONNECTION
     - PORT= $PORT
 


### PR DESCRIPTION
Displays non-SG timezone currently. (Docker default TZ). For SG context it should be SG TZ. Allows docker to be run on SG TZ.